### PR TITLE
Use GitHub Actions to deploy to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          if: github.ref == 'ref/head/master'
+        if: github.ref == 'ref/head/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: npm install --production
       - name: Build
-        run: npm run build --prefix-paths
+        run: npm run build -- --prefix-paths
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Gatsby Publish
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          deploy-branch: gh-pages
+          gatsby-args: --prefix-paths
+          skip-publish: ${{ github.ref != 'master' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           node-version: 14.x
       - name: Install dependencies
-        run: yarn install --prod --pure-lockfile
+        run: npm install --production
       - name: Build
-        run: yarn build --prefix-paths
+        run: npm run build --prefix-paths
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: enriikke/gatsby-gh-pages-action@v2
+      - name: Use Node.js
+        uses: actions/setup-node@master
         with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
-          deploy-branch: gh-pages
-          gatsby-args: --prefix-paths
-          skip-publish: ${{ github.ref != 'master' }}
+          node-version: 14.x
+      - name: Install dependencies
+        run: yarn install --prod --pure-lockfile
+      - name: Build
+        run: yarn build --prefix-paths
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          if: github.ref == 'ref/head/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-        if: github.ref == 'ref/head/master'
+        if: github.ref == 'ref/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-        if: github.ref == 'ref/heads/master'
+        if: github.ref == 'refs/heads/master'

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-royalhackaway.com

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  pathPrefix: "/zhac/240/",
+  pathPrefix: "/royalhackaway.com/",
   siteMetadata: {
     title: "Royal Hackaway",
     description:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "Royal Holloway Computing Society <hello@computingsociety.co.uk>",
   "dependencies": {
     "bootstrap": "^4.5.2",
-    "classnames": "^2.2.6",
     "gatsby": "^2.24.61",
     "gatsby-image": "^2.4.19",
     "gatsby-plugin-manifest": "^2.4.30",
@@ -24,15 +23,15 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-helmet": "^6.1.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "eslint-config-prettier": "^6.12.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react": "^7.21.2",
+    "gatsby-plugin-eslint": "^2.0.8"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
-    "eslint-config-prettier": "^6.12.0",
-    "eslint-plugin-prettier": "^3.1.4",
-    "eslint-plugin-react": "^7.21.2",
-    "gatsby-plugin-eslint": "^2.0.8",
     "prettier": "2.1.1"
   },
   "keywords": [


### PR DESCRIPTION
This commit adds the relevant GitHub Actions yaml file to automatically build and deploy the site to GitHub Pages.
`gatsby-config.js` has been modified temporarily to be able to be viewed under a directory (and not at the root of the website)